### PR TITLE
Add trailing slash config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,4 +4,5 @@ module.exports = {
     loader: 'custom',
     domains: ['res.cloudinary.com'],
   },
+  trailingSlash: true,
 }


### PR DESCRIPTION
It was added `trailingSlash` on next.conf.js to access page `/en`